### PR TITLE
Host always set to `localhost`

### DIFF
--- a/testcontainers/postgres.py
+++ b/testcontainers/postgres.py
@@ -46,7 +46,7 @@ class PostgresContainer(DbContainer):
         self.with_env("POSTGRES_PASSWORD", self.POSTGRES_PASSWORD)
         self.with_env("POSTGRES_DB", self.POSTGRES_DB)
 
-    def get_connection_url(self, host="localhost"):
+    def get_connection_url(self, host=None):
         return super()._create_connection_url(dialect="postgresql+psycopg2",
                                               username=self.POSTGRES_USER,
                                               password=self.POSTGRES_PASSWORD,


### PR DESCRIPTION
At the moment using a host other than `localhost` will fail because `generic.py` line 26 calls `self.get_connection_url()` without a host param which defaults to `localhost.`

This PR corrects this by setting host to None per default. The host will then correctly be assigned in `_create_connection_url` using `get_container_host_ip`.